### PR TITLE
MLFE compiler v0.2.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
 {erl_opts, [debug_info]}.
-{deps, [{mlfe, {git, "https://github.com/j14159/mlfe.git", {branch, "v0.2.0-WIP"}}}]}.
+{deps, [{mlfe, {git, "https://github.com/j14159/mlfe.git", {tag, "v0.2.0"}}}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
 {erl_opts, [debug_info]}.
-{deps, [{mlfe, {git, "https://github.com/tsloughter/mlfe.git", {branch, "master"}}}]}.
+{deps, [{mlfe, {git, "https://github.com/j14159/mlfe.git", {branch, "v0.2.0-WIP"}}}]}.

--- a/src/rebar_prv_mlfe_compile.erl
+++ b/src/rebar_prv_mlfe_compile.erl
@@ -33,6 +33,7 @@ do(State) ->
                   AppInfo ->
                       [AppInfo]
               end,
+    TestsEnabled = [P || P <- rebar_state:current_profiles(State), P == test],
     [begin
          %% Opts = rebar_app_info:opts(AppInfo),
          EBinDir = rebar_app_info:ebin_dir(AppInfo),
@@ -40,7 +41,7 @@ do(State) ->
          FoundFiles = rebar_utils:find_files(SourceDir, ".*\\.mlfe\$"),
 
          [file:write_file(filename:join(EBinDir, FileName), BeamBinary) ||
-             {compiled_module, ModuleName, FileName, BeamBinary} <- mlfe:compile({files, FoundFiles})]
+             {compiled_module, ModuleName, FileName, BeamBinary} <- mlfe:compile({files, FoundFiles}, TestsEnabled)]
      end || AppInfo <- Apps],
 
     {ok, State}.


### PR DESCRIPTION
Uses the new v0.2.0 tag, enables eunit test generation.

There appears to be a minor bug in that the first run of `rebar3 eunit` doesn't run the tests in `.mfle` files but subsequent runs have no trouble.  Something I'll start looking into for 0.2.1 or 0.3.0 I think.
