### PR TITLE
Fixed compiled output pattern match issue

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,1 @@
-[{<<"alpaca">>,
-  {git,"https://github.com/alpaca-lang/alpaca.git",
-       {ref,"4338a2c79451c529c612911872acba765061814b"}},
-  0},
- {<<"apcshell">>,
-  {git,"https://github.com/lepoetemaudit/alpaca-repl.git",
-       {ref,"ab5b8db4b6c0931fb6840d094533fc7f0d56d1c0"}},
-  0}].
+[].

--- a/src/rebar_prv_alpaca_compile.erl
+++ b/src/rebar_prv_alpaca_compile.erl
@@ -40,8 +40,9 @@ do(State) ->
          SourceDir = filename:join(rebar_app_info:dir(AppInfo), "src"),
          FoundFiles = rebar_utils:find_files(SourceDir, ".*\\.alp\$"),
 
+         {ok, Compiled} = alpaca:compile({files, FoundFiles}, TestsEnabled),
          [file:write_file(filename:join(EBinDir, FileName), BeamBinary) ||
-             {compiled_module, ModuleName, FileName, BeamBinary} <- alpaca:compile({files, FoundFiles}, TestsEnabled)]
+             {compiled_module, ModuleName, FileName, BeamBinary} <- Compiled]
      end || AppInfo <- Apps],
 
     {ok, State}.


### PR DESCRIPTION
Turned up while I was playing around with some alpaca_lib ideas.  Also
cleared out the lock file as it was targeting an old version of the
Alpaca compiler.