### PR TITLE
Overhaul everything.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ rebar3 plugin for compiling [alpaca](https://github.com/alpaca-lang/alpaca) modu
 Use
 ---
 
+From 0.2.8, Alpaca must be installed. Please see instructions at http://alpaca-lang.org.
+
 Add the plugin to your rebar config:
 
 ```
 {plugins, [
-    {rebar_prv_alpaca, ".*", {git, "https://github.com/tsloughter/rebar_prv_alpaca.git", {branch, "master"}}}
+    {rebar_prv_alpaca, ".*", {git, "https://github.com/alpaca/rebar_prv_alpaca.git", {branch, "master"}}}
 ]}.
 
 
@@ -18,15 +20,37 @@ Add the plugin to your rebar config:
 ```
 
 
+Options
+---
+
+Options can be passed to the Alpaca compiler via a `{rebar_prv_alpaca, ... }` section in your rebar.config
+file. Currently, the only option supported is for default imports (i.e. functions and types that can be
+implictly included in all your modules), e.g.
 
 ```
-$ rebar3 alpaca shell
-...
- == Alpaca Shell 0.02a ==
-
- (hint: exit with ctrl-c, run expression by terminating with ';;' or an empty line)
-
- -> add x y = x + y ;;
- -> add 10 20 ;;
--- 30
+{rebar_prv_alpaca, 
+	[ { default_imports, [ {default, list_defaults} ] } ]
+}.
 ```
+
+`default_imports` takes a list of tuples of `{Module, Function}`. In the instance above
+it might live in a module that looks like this:
+
+```
+-module(default).
+-export([list_defaults/0]).
+
+list_defaults() ->
+    Funs = [{assert, <<"equal">>}],
+    Types = [{utils, <<"Result">>}],
+    {Funs, Types}.
+```
+
+The `list_defaults/0` function returns a tuple of {[FunctionRef], [TypeRef]}.
+These functions and types will then be injected into each of your modules.
+
+The intention behind this is that most of the time you will simply wish to
+reference a "default" set of imports from Alpaca's own standard library (which
+is a work in prgress) but that ultimately you could pull in other standard
+libraries or save on explicitly importing functions and types you use 
+everywhere.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
-rebar_prv_alpaca
+Alpaca - Rebar3 Plugin
 =====
 
-rebar3 plugin for compiling [alpaca](https://github.com/alpaca-lang/alpaca) modules.
+A rebar3 plugin for compiling [alpaca](https://github.com/alpaca-lang/alpaca) modules.
+
+Alpaca modules will be compiled alongside Erlang ones. Pulling in other Alpaca 
+libraries as dependencies as well as performing incremental builds is also supported.
 
 Use
 ---
 
 From 0.2.8, Alpaca must be installed. Please see instructions at http://alpaca-lang.org.
+Essentially, you need to download an appropriate release from 
+https://github.com/alpaca-lang/alpaca/releases and ensure it is saved either in a well-known
+location (`/usr/lib/alpaca`, `/usr/local/lib/alpaca`, or `/opt/alpaca`) or install it
+wherever you wish and set the `ALPACA_ROOT` environmental variable to the path where you
+placed the Alpaca release.
 
 Add the plugin to your rebar config:
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
 {erl_opts, [debug_info]}.
-{deps, [{alpaca, {git, "https://github.com/alpaca-lang/alpaca.git", {tag, "v0.2.7"}}},
-        {apcshell, {git, "https://github.com/lepoetemaudit/alpaca-repl.git", {branch, "master"}}}]}.
+{deps, [{epo_runtime, {git, "git://github.com/brigadier/epo_runtime.git",
+                        {tag, "0.3"}}}
+       ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {erl_opts, [debug_info]}.
 {deps, [{epo_runtime, {git, "git://github.com/brigadier/epo_runtime.git",
-                        {tag, "0.3"}}}
+                        {tag, "0.3"}}}, cf
        ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,4 @@
-[].
+[{<<"epo_runtime">>,
+  {git,"git://github.com/brigadier/epo_runtime.git",
+       {ref,"a3e50e7cebb526f833757e867bbe914c1da7baa3"}},
+  0}].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,10 @@
-[{<<"epo_runtime">>,
+{"1.1.0",
+[{<<"cf">>,{pkg,<<"cf">>,<<"0.3.1">>},0},
+ {<<"epo_runtime">>,
   {git,"git://github.com/brigadier/epo_runtime.git",
        {ref,"a3e50e7cebb526f833757e867bbe914c1da7baa3"}},
-  0}].
+  0}]}.
+[
+{pkg_hash,[
+ {<<"cf">>, <<"5CB902239476E141EA70A740340233782D363A31EEA8AD37049561542E6CD641">>}]}
+].

--- a/src/rebar_prv_alpaca_compile.erl
+++ b/src/rebar_prv_alpaca_compile.erl
@@ -1,6 +1,6 @@
 -module(rebar_prv_alpaca_compile).
 
--export([init/1, do/1, format_error/1]).
+-export([init/1, do/1, format_error/1, compile_dir/5]).
 
 -define(PROVIDER, compile).
 -define(NAMESPACE, alpaca).
@@ -28,143 +28,151 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     %% Locate Alpaca compiler
-    AlpacaHome = os:getenv("ALPACA_ROOT", "/usr/local/opt/alpaca/ebin"),
-    code:add_path(AlpacaHome),
+    AlpacaPaths = [
+                   os:getenv("ALPACA_ROOT"),
+                   "/usr/lib/alpaca",
+                   "/usr/local/lib/alpaca"],
+    AlpacaHome = get_best_path(AlpacaPaths),
+    code:add_path(AlpacaHome ++ "/beams"),
     AlpacaModules =
         [alpaca, alpaca_ast, alpaca_ast_gen, alpaca_codegen,
          alpaca_compiled_po, alpaca_error_format, alpaca_exhaustiveness,
          alpaca_parser, alpaca_scan, alpaca_scanner, alpaca_typer],
-    ok = code:ensure_modules_loaded(AlpacaModules),
-
-    Locale = case string:tokens(os:getenv("LANG", "en_US"), ".") of
-        [L, _] -> L;
-        L -> L
+    case code:ensure_modules_loaded(AlpacaModules) of
+        ok -> ok;
+        _ -> abort_no_alpaca()
     end,
-
+  
     Apps = case rebar_state:current_app(State) of
                   undefined ->
                       rebar_state:project_apps(State);
                   AppInfo ->
                       [AppInfo]
               end,
-    Version = proplists:get_value(version, alpaca:compiler_info()),
     TestsEnabled = [P || P <- rebar_state:current_profiles(State), P == test],
     [begin
          EBinDir = rebar_app_info:ebin_dir(AppInfo),
-         Opts = rebar_app_info:opts(AppInfo),
          SourceDir = filename:join(rebar_app_info:dir(AppInfo), "src"),
-         Info = rebar_dir:src_dirs(Opts),
-
          SourceFiles = rebar_utils:find_files(SourceDir, ".*\\.alp\$"),
          Deps = rebar_state:all_deps(State),
          LocalBeamFiles = rebar_utils:find_files(EBinDir, ".*\\.beam\$"),
          DependencyBeamFiles = lists:flatmap(fun gather_beam_files/1, Deps),
-
-         %% initial pass - iterate over source files, extract their dependencies,
-         %% and figure out if (the files themselves) require compilation -
-         %% i.e. BEAM file missing or mismatches the source hash
-         FileGraph = lists:foldl(
-             fun(F, Graph) ->
-                 {ok, Src} = file:read_file(F),
-                 {Mod, ModDeps} = alpaca:list_dependencies(Src),
-
-                 maps:put(Mod, {F, ModDeps, is_dirty(LocalBeamFiles, F, Src)}, Graph)
-             end,
-             maps:new(),
-             SourceFiles),
-
-         %% Next, we figure out which modules are dirty due to
-         %% modules depended upon that require recompilation
-         GetHasDirtyDeps = fun DirtyDeps(Mod, Map) ->
-             {_, ModDeps, IsDirty} = maps:get(Mod, Map, {unknown, [], false}),
-             case IsDirty of
-                 true -> true;
-                 false ->
-                     Dirty = lists:map(fun(M) -> DirtyDeps(M, Map) end, ModDeps),
-                     lists:any(fun(X) -> X =:= true end, Dirty)
-            end
-         end,
-
-         %% We update the file graph with the list of dirty dependencies
-         FileGraph2 = maps:map(
-             fun(_, {_, _, true} = V) -> V;
-                (Mod, {F, ModDeps, false}) ->
-                    {F, ModDeps, GetHasDirtyDeps(Mod, FileGraph)}
-             end,
-             FileGraph),
-
-         %% Create a directed graph so we can topologically sort
-         %% the modules in order of dependency
-         DiGraph = digraph:new(),
-
-         %% Each 'vertex' is a module
-         lists:map(
-            fun(Mod) ->
-                digraph:add_vertex(DiGraph, Mod)
-            end,
-            maps:keys(FileGraph2)),
-
-         %% Each 'edge' is a dependency relationship between them
-         maps:map(
-             fun(Mod, {_, ModDeps, _}) ->
-                 lists:map(fun(OtherMod) ->
-                     digraph:add_edge(DiGraph, OtherMod, Mod)
-                 end, ModDeps)
-             end,
-             FileGraph2),
-
-         %% Generate the topological ordering
-         Sorted = digraph_utils:topsort(DiGraph),
-
-         %% Map the final list into .beam / .alp filepaths
-         GatheredLocalFiles = lists:map(
-             fun(Mod) ->
-                 {F, _, IsDirty} = maps:get(Mod, FileGraph2),
-                 case IsDirty of
-                    true -> F;
-                    false ->
-                        {ok, BF} = get_beam_file(F, LocalBeamFiles),
-                        BF
-                end
-             end,
-             Sorted),
-
-         %% Of course, if we don't have any .alp files in the final
-         %% list, we don't even need to invoke compilation
-         case lists:all(fun(F) ->
-                            filename:extension(F) == ".beam"
-                        end,
-                        GatheredLocalFiles) of
-             true -> ok;
-             false ->
-                CompileFiles = DependencyBeamFiles ++ GatheredLocalFiles,
-                rebar_api:debug("Sending files to Alpaca compiler: ~p~n", [CompileFiles]),
-                Sources = lists:filter(
-                    fun(F) ->
-                        filename:extension(F) == ".alp"
-                    end,
-                    GatheredLocalFiles),
-
-                rebar_api:info(
-                    "Alpaca ~s: compiling ~s~n",
-                    [Version,
-                     string:join(
-                         lists:map(fun filename:basename/1, Sources),
-                         ", ")]),
-
-                case alpaca:compile({files, CompileFiles}, TestsEnabled) of
-                    {ok, Compiled} ->
-                        [file:write_file(filename:join(EBinDir, FileName), BeamBinary) ||
-                        {compiled_module, _, FileName, BeamBinary} <- Compiled];
-
-                    {error, _} = E ->
-                        Error = alpaca_error_format:fmt(E, Locale),
-                        throw({error, {?MODULE, Error}})
-                end
-        end
-
+         compile_dir(SourceFiles, LocalBeamFiles, DependencyBeamFiles, EBinDir, TestsEnabled)
      end || AppInfo <- Apps],
     {ok, State}.
+
+compile_dir(SourceFiles, LocalBeamFiles, DependencyBeamFiles, EBinDir, TestsEnabled) ->
+    %% Get Alpaca version so we can display it when compiling source
+    Version = proplists:get_value(version, alpaca:compiler_info()),
+    
+    %% Get User LOCALE so we can display translated error messages, if available
+    Locale = case string:tokens(os:getenv("LANG", "en_US"), ".") of
+                 [L, _] -> L;
+                 L -> L
+             end,
+
+    %% initial pass - iterate over source files, extract their dependencies,
+    %% and figure out if (the files themselves) require compilation -
+    %% i.e. BEAM file missing or mismatches the source hash
+    FileGraph = lists:foldl(
+        fun(F, Graph) ->
+            {ok, Src} = file:read_file(F),
+            {Mod, ModDeps} = alpaca:list_dependencies(Src),
+
+            maps:put(Mod, {F, ModDeps, is_dirty(LocalBeamFiles, F, Src)}, Graph)
+        end,
+        maps:new(),
+        SourceFiles),
+
+    %% Next, we figure out which modules are dirty due to
+    %% modules depended upon that require recompilation
+    GetHasDirtyDeps = fun DirtyDeps(Mod, Map) ->
+        {_, ModDeps, IsDirty} = maps:get(Mod, Map, {unknown, [], false}),
+        case IsDirty of
+            true -> true;
+            false ->
+                Dirty = lists:map(fun(M) -> DirtyDeps(M, Map) end, ModDeps),
+                lists:any(fun(X) -> X =:= true end, Dirty)
+    end
+    end,
+
+    %% We update the file graph with the list of dirty dependencies
+    FileGraph2 = maps:map(
+        fun(_, {_, _, true} = V) -> V;
+        (Mod, {F, ModDeps, false}) ->
+            {F, ModDeps, GetHasDirtyDeps(Mod, FileGraph)}
+        end,
+        FileGraph),
+
+    %% Create a directed graph so we can topologically sort
+    %% the modules in order of dependency
+    DiGraph = digraph:new(),
+
+    %% Each 'vertex' is a module
+    lists:map(
+    fun(Mod) ->
+        digraph:add_vertex(DiGraph, Mod)
+    end,
+    maps:keys(FileGraph2)),
+
+    %% Each 'edge' is a dependency relationship between them
+    maps:map(
+        fun(Mod, {_, ModDeps, _}) ->
+            lists:map(fun(OtherMod) ->
+                digraph:add_edge(DiGraph, OtherMod, Mod)
+            end, ModDeps)
+        end,
+        FileGraph2),
+
+    %% Generate the topological ordering
+    Sorted = digraph_utils:topsort(DiGraph),
+
+    %% Map the final list into .beam / .alp filepaths
+    GatheredLocalFiles = lists:map(
+        fun(Mod) ->
+            {F, _, IsDirty} = maps:get(Mod, FileGraph2),
+            case IsDirty of
+            true -> F;
+            false ->
+                {ok, BF} = get_beam_file(F, LocalBeamFiles),
+                BF
+        end
+        end,
+        Sorted),
+
+    %% Of course, if we don't have any .alp files in the final
+    %% list, we don't even need to invoke compilation
+    case lists:all(fun(F) ->
+                    filename:extension(F) == ".beam"
+                end,
+                GatheredLocalFiles) of
+        true -> ok;
+        false ->
+        CompileFiles = DependencyBeamFiles ++ GatheredLocalFiles,
+        rebar_api:debug("Sending files to Alpaca compiler: ~p~n", [CompileFiles]),
+        Sources = lists:filter(
+            fun(F) ->
+                filename:extension(F) == ".alp"
+            end,
+            GatheredLocalFiles),
+
+        rebar_api:info(
+            "Alpaca ~s: compiling ~s~n",
+            [Version,
+                string:join(
+                    lists:map(fun filename:basename/1, Sources),
+                    ", ")]),
+
+        case alpaca:compile({files, CompileFiles}, TestsEnabled) of
+            {ok, Compiled} ->
+                [file:write_file(filename:join(EBinDir, FileName), BeamBinary) ||
+                {compiled_module, _, FileName, BeamBinary} <- Compiled];
+
+            {error, _} = E ->
+                Error = alpaca_error_format:fmt(E, Locale),
+                throw({error, {?MODULE, Error}})
+        end
+     end.
 
 get_beam_file(Filename, BeamFiles) ->
     [ModuleName, _] = string:tokens(filename:basename(Filename), "."),
@@ -199,9 +207,30 @@ is_dirty(BeamFiles, Filename, SrcText) ->
 
 gather_beam_files(Dep) ->
     EbinDir = rebar_app_info:ebin_dir(Dep),
-    rebar_utils:find_files(EbinDir, "alpaca_.*\\.beam\$").
+    PossibleAlpacaFiles = rebar_utils:find_files(EbinDir, "alpaca_.*\\.beam\$"),
+    lists:filter(fun(Mod) -> case alpaca:retrieve_hash(Mod) of
+                                 undefined -> false;
+                                 _ -> true
+                             end
+                 end, PossibleAlpacaFiles).
 
 -spec format_error(any()) ->  iolist().
 format_error(Reason) ->
     io_lib:format("Alpaca compile error: ~s", [Reason]).
 
+
+get_best_path([]) ->
+    "/opt/alpaca";
+get_best_path([Path | Rest]) ->
+    case filelib:is_dir(Path) of
+        true -> Path;
+        false -> get_best_path(Rest)
+    end.
+
+abort_no_alpaca() ->
+    io:put_chars(
+      standard_error, "Error: Cannot find Alpaca. Please follow"
+      " instructions at http://alpaca-lang.org\n"),
+    halt(1, []).
+
+    

--- a/src/rebar_prv_alpaca_compile.erl
+++ b/src/rebar_prv_alpaca_compile.erl
@@ -4,7 +4,7 @@
 
 -define(PROVIDER, compile).
 -define(NAMESPACE, alpaca).
--define(DEPS, [{default, lock}]).
+-define(DEPS, [{default, compile}]).
 
 %% ===================================================================
 %% Public API
@@ -27,40 +27,181 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    %% Locate Alpaca compiler
+    AlpacaHome = os:getenv("ALPACA_ROOT", "/usr/local/opt/alpaca/ebin"),
+    code:add_path(AlpacaHome),
+    AlpacaModules =
+        [alpaca, alpaca_ast, alpaca_ast_gen, alpaca_codegen,
+         alpaca_compiled_po, alpaca_error_format, alpaca_exhaustiveness,
+         alpaca_parser, alpaca_scan, alpaca_scanner, alpaca_typer],
+    ok = code:ensure_modules_loaded(AlpacaModules),
+
+    Locale = case string:tokens(os:getenv("LANG", "en_US"), ".") of
+        [L, _] -> L;
+        L -> L
+    end,
+
     Apps = case rebar_state:current_app(State) of
                   undefined ->
                       rebar_state:project_apps(State);
                   AppInfo ->
                       [AppInfo]
               end,
+    Version = proplists:get_value(version, alpaca:compiler_info()),
     TestsEnabled = [P || P <- rebar_state:current_profiles(State), P == test],
     [begin
          EBinDir = rebar_app_info:ebin_dir(AppInfo),
          Opts = rebar_app_info:opts(AppInfo),
          SourceDir = filename:join(rebar_app_info:dir(AppInfo), "src"),
-         Info = rebar_dir:src_dirs(Opts),         
-         
-         FoundFiles = rebar_utils:find_files(SourceDir, ".*\\.alp\$"),
+         Info = rebar_dir:src_dirs(Opts),
+
+         SourceFiles = rebar_utils:find_files(SourceDir, ".*\\.alp\$"),
          Deps = rebar_state:all_deps(State),
+         LocalBeamFiles = rebar_utils:find_files(EBinDir, ".*\\.beam\$"),
+         DependencyBeamFiles = lists:flatmap(fun gather_beam_files/1, Deps),
 
-         AllFoundFiles = FoundFiles ++ lists:flatmap(fun gather_files/1, Deps),
+         %% initial pass - iterate over source files, extract their dependencies,
+         %% and figure out if (the files themselves) require compilation -
+         %% i.e. BEAM file missing or mismatches the source hash
+         FileGraph = lists:foldl(
+             fun(F, Graph) ->
+                 {ok, Src} = file:read_file(F),
+                 {Mod, ModDeps} = alpaca:list_dependencies(Src),
 
-         case alpaca:compile({files, AllFoundFiles}, TestsEnabled) of
-             {ok, Compiled} ->
-                [file:write_file(filename:join(EBinDir, FileName), BeamBinary) ||
-                 {compiled_module, ModuleName, FileName, BeamBinary} <- Compiled];
-             {error, Reason} ->
-                 io:format(standard_error, "Compile error: ~s", format_error(Reason))
-         end
+                 maps:put(Mod, {F, ModDeps, is_dirty(LocalBeamFiles, F, Src)}, Graph)
+             end,
+             maps:new(),
+             SourceFiles),
+
+         %% Next, we figure out which modules are dirty due to
+         %% modules depended upon that require recompilation
+         GetHasDirtyDeps = fun DirtyDeps(Mod, Map) ->
+             {_, ModDeps, IsDirty} = maps:get(Mod, Map, {unknown, [], false}),
+             case IsDirty of
+                 true -> true;
+                 false ->
+                     Dirty = lists:map(fun(M) -> DirtyDeps(M, Map) end, ModDeps),
+                     lists:any(fun(X) -> X =:= true end, Dirty)
+            end
+         end,
+
+         %% We update the file graph with the list of dirty dependencies
+         FileGraph2 = maps:map(
+             fun(_, {_, _, true} = V) -> V;
+                (Mod, {F, ModDeps, false}) ->
+                    {F, ModDeps, GetHasDirtyDeps(Mod, FileGraph)}
+             end,
+             FileGraph),
+
+         %% Create a directed graph so we can topologically sort
+         %% the modules in order of dependency
+         DiGraph = digraph:new(),
+
+         %% Each 'vertex' is a module
+         lists:map(
+            fun(Mod) ->
+                digraph:add_vertex(DiGraph, Mod)
+            end,
+            maps:keys(FileGraph2)),
+
+         %% Each 'edge' is a dependency relationship between them
+         maps:map(
+             fun(Mod, {_, ModDeps, _}) ->
+                 lists:map(fun(OtherMod) ->
+                     digraph:add_edge(DiGraph, OtherMod, Mod)
+                 end, ModDeps)
+             end,
+             FileGraph2),
+
+         %% Generate the topological ordering
+         Sorted = digraph_utils:topsort(DiGraph),
+
+         %% Map the final list into .beam / .alp filepaths
+         GatheredLocalFiles = lists:map(
+             fun(Mod) ->
+                 {F, _, IsDirty} = maps:get(Mod, FileGraph2),
+                 case IsDirty of
+                    true -> F;
+                    false ->
+                        {ok, BF} = get_beam_file(F, LocalBeamFiles),
+                        BF
+                end
+             end,
+             Sorted),
+
+         %% Of course, if we don't have any .alp files in the final
+         %% list, we don't even need to invoke compilation
+         case lists:all(fun(F) ->
+                            filename:extension(F) == ".beam"
+                        end,
+                        GatheredLocalFiles) of
+             true -> ok;
+             false ->
+                CompileFiles = DependencyBeamFiles ++ GatheredLocalFiles,
+                rebar_api:debug("Sending files to Alpaca compiler: ~p~n", [CompileFiles]),
+                Sources = lists:filter(
+                    fun(F) ->
+                        filename:extension(F) == ".alp"
+                    end,
+                    GatheredLocalFiles),
+
+                rebar_api:info(
+                    "Alpaca ~s: compiling ~s~n",
+                    [Version,
+                     string:join(
+                         lists:map(fun filename:basename/1, Sources),
+                         ", ")]),
+
+                case alpaca:compile({files, CompileFiles}, TestsEnabled) of
+                    {ok, Compiled} ->
+                        [file:write_file(filename:join(EBinDir, FileName), BeamBinary) ||
+                        {compiled_module, _, FileName, BeamBinary} <- Compiled];
+
+                    {error, _} = E ->
+                        Error = alpaca_error_format:fmt(E, Locale),
+                        throw({error, {?MODULE, Error}})
+                end
+        end
+
      end || AppInfo <- Apps],
-
     {ok, State}.
 
-gather_files(AppInfo) ->
-    SourceDir = filename:join(rebar_app_info:dir(AppInfo), "src"),
-    rebar_utils:find_files(SourceDir, ".*\\.alp\$").
-   
+get_beam_file(Filename, BeamFiles) ->
+    [ModuleName, _] = string:tokens(filename:basename(Filename), "."),
+    BeamName = "alpaca_" ++ ModuleName ++ ".beam",
+    BFS = lists:filter(
+        fun(F) ->
+            filename:basename(F) == BeamName
+        end, BeamFiles),
+    case BFS of
+        [BF] -> {ok, BF};
+        [] -> {error, no_file};
+        _ -> {error, duplicate_filename, BFS}
+    end.
+
+is_dirty(BeamFiles, Filename, SrcText) ->
+    case get_beam_file(Filename, BeamFiles) of
+        {ok, BeamMod} ->
+            %% We have a BEAM File, compare the hashes
+            SrcHash = alpaca:hash_source(unicode:characters_to_list(SrcText)),
+            BeamHash = alpaca:retrieve_hash(BeamMod),
+            case {SrcHash, BeamHash} of
+                %% Hashes match, unchanged
+                {_S, _S} -> false;
+                %% Hashes differ, it has changed
+                _ -> true
+            end;
+
+        {error, no_file} ->
+            %% No BEAM file, compile the source file
+            true
+    end.
+
+gather_beam_files(Dep) ->
+    EbinDir = rebar_app_info:ebin_dir(Dep),
+    rebar_utils:find_files(EbinDir, "alpaca_.*\\.beam\$").
 
 -spec format_error(any()) ->  iolist().
 format_error(Reason) ->
-    io_lib:format("~p", [Reason]).
+    io_lib:format("Alpaca compile error: ~s", [Reason]).
+

--- a/src/rebar_prv_alpaca_compile.erl
+++ b/src/rebar_prv_alpaca_compile.erl
@@ -48,12 +48,15 @@ do(State) ->
                       rebar_state:project_apps(State);
                   AppInfo ->
                       [AppInfo]
-              end,
+           end,
     TestsEnabled = [P || P <- rebar_state:current_profiles(State), P == test],
     [begin
          EBinDir = rebar_app_info:ebin_dir(AppInfo),
          SourceDir = filename:join(rebar_app_info:dir(AppInfo), "src"),
-         Opts = dict:fetch(rebar_prv_alpaca, rebar_app_info:opts(AppInfo)),
+         Opts = case dict:find(rebar_prv_alpaca, rebar_app_info:opts(AppInfo)) of
+             {ok, O} -> O;
+             error -> []
+         end,
          SourceFiles = rebar_utils:find_files(SourceDir, ".*\\.alp\$"),
          Deps = rebar_state:all_deps(State),
          LocalBeamFiles = rebar_utils:find_files(EBinDir, ".*\\.beam\$"),
@@ -185,7 +188,7 @@ compile_dir(SourceFiles, LocalBeamFiles, DependencyBeamFiles,
 
         CompileOpts = TestsEnabled ++
                 case proplists:get_value(default_imports, Opts) of
-                    nil -> [];
+                    undefined -> [];
                     Imports -> [{default_imports, gather_imports(Imports)}]
                 end,
 
@@ -258,7 +261,7 @@ gather_imports(Imports) ->
 
 -spec format_error(any()) ->  iolist().
 format_error(Reason) ->
-    io_lib:format("Alpaca compile error: ~s", [Reason]).
+    io_lib:format("Alpaca compile error: \n\033[0m~s", [Reason]).
 
 
 get_best_path([]) ->


### PR DESCRIPTION
Alpaca itself is now loaded from an ebin folder, specfied in $ALPACA_ROOT in the environment or "/usr/local/opt/alpaca/ebin". This makes it very easy to install distributions of Alpaca, and also to develop against dev versions of Alpaca / switch versions too. I think we should just bundle the whole source tree up, but compiled and with all the generated beam files stored in ./ebin. Installation could be a single line of shell script, i.e. `curl $ALPACA_RELEASE | tar -xz -C /usr/local/opt`.

This plugin will now attempt to use precompiled beam files of modules, order things in dependency order, and correctly identify when a module has to be recompiled. Errors are also formatted using Alpaca's error formatting module, and the locale read from the environment.